### PR TITLE
Fix broken output from Utils.secs_to_string

### DIFF
--- a/lib/rbot/core/utils/utils.rb
+++ b/lib/rbot/core/utils/utils.rb
@@ -198,7 +198,7 @@ module ::Irc
       when 0
         raise "Empty ret array!"
       when 1
-        return ret.to_s
+        return ret[0].to_s
       else
         return [ret[0, ret.length-1].join(", ") , ret[-1]].join(_(" and "))
       end


### PR DESCRIPTION
Utils.secs_to_string(360) now returns "6 minutes" instead of "["6 minutes"]".
