### PR TITLE
Revert "always print FATAL and ERROR logmessages to STDERR"

### DIFF
--- a/lib/rbot/ircbot.rb
+++ b/lib/rbot/ircbot.rb
@@ -66,10 +66,6 @@ def rawlog(level, message=nil, who_pos=1)
     qmsg.push [level, l.chomp, who]
     who = ' ' * who.size
   }
-  # Also output (fatal) errors to STDERR:
-  if level == Logger::Severity::ERROR or level == Logger::Severity::FATAL
-    $stderr.puts str
-  end
   $log_queue.push qmsg
 end
 


### PR DESCRIPTION
This reverts commit c4d629ad86aae3b8bb4669650df57875252bea92.

Apparently this crashes the bot sometimes when attempting to write to STDERR from a backgrounded process. Looks like it blocks forever or something :(
